### PR TITLE
quote sources paths

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -287,7 +287,8 @@ getPaths = do
 listSourcePaths :: IO ()
 listSourcePaths = do
   paths <- getPaths
-  traverse_ (echoT . pathToTextUnsafe) paths
+  traverse_ (echoT . quote . pathToTextUnsafe) paths
+  where quote s = '\'' `T.cons` (s `T.snoc` '\'')
 
 exec :: [String] -> Bool -> IO ()
 exec execNames onlyDeps = do


### PR DESCRIPTION
`psc-package sources` outputs globs. Those globs will be expanded in
funny ways by shells like BASH when they are provided as parameters to
other shell commands, forcing users to set their shell mode to 'noglob'.

This commit quotes each line of output so that users don't have to do
this.