### PR TITLE
Add a newtype for package names

### DIFF
--- a/app/Types.hs
+++ b/app/Types.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Types
+  ( PackageName
+  , mkPackageName
+  , runPackageName
+  , preludePackageName
+  , untitledPackageName
+  ) where
+
+import           Control.Category ((>>>))
+import           Data.Aeson (FromJSON, ToJSON, FromJSONKey(..), ToJSONKey(..), ToJSONKeyFunction(..), FromJSONKeyFunction(..), parseJSON, toJSON, withText)
+import qualified Data.Aeson.Encoding as AesonEncoding
+import           Data.Char (isAscii, isLower, isDigit)
+import           Data.Monoid ((<>))
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+newtype PackageName
+  = PackageName Text
+  deriving (Show, Eq, Ord)
+
+instance ToJSON PackageName where
+  toJSON (PackageName t) = toJSON t
+
+instance FromJSON PackageName where
+  parseJSON =
+    withText "package name" fromText
+    
+fromText :: Monad m => Text -> m PackageName
+fromText t =
+  case mkPackageName t of
+    Right pkgName -> pure pkgName
+    Left errs -> fail $ "Invalid package name: " <> show errs
+
+instance ToJSONKey PackageName where
+  toJSONKey =
+    ToJSONKeyText
+      runPackageName
+      (AesonEncoding.text . runPackageName)
+
+instance FromJSONKey PackageName where
+  fromJSONKey =
+    FromJSONKeyTextParser fromText
+
+data PackageNameError
+  = NotEmpty
+  | TooLong Int
+  | InvalidChars [Char]
+  | RepeatedSeparators
+  | MustNotBeginSeparator
+  | MustNotEndSeparator
+  deriving (Show, Eq, Ord)
+
+-- | Smart constructor for package names. Based on Bower's requirements for
+-- | package names.
+mkPackageName :: Text -> Either PackageNameError PackageName
+mkPackageName = fmap PackageName . validateAll validators
+  where
+  dashOrDot = ['-', '.']
+  validateAll vs x = mapM_ (validateWith x) vs >> return x
+  validateWith x (p, err)
+    | p x       = Right x
+    | otherwise = Left (err x)
+  validChar c = isAscii c && (isLower c || isDigit c || c `elem` dashOrDot)
+  validators =
+      [ (not . T.null, const NotEmpty)
+      , (T.all validChar, InvalidChars . T.unpack . T.filter (not . validChar))
+      , (firstChar (`notElem` dashOrDot), const MustNotBeginSeparator)
+      , (lastChar (`notElem` dashOrDot), const MustNotEndSeparator)
+      , (not . T.isInfixOf "--", const RepeatedSeparators)
+      , (not . T.isInfixOf "..", const RepeatedSeparators)
+      , (T.length >>> (<= 50), TooLong . T.length)
+      ]
+  firstChar p str = not (T.null str) && p (T.index str 0)
+  lastChar p = firstChar p . T.reverse
+
+runPackageName :: PackageName -> Text
+runPackageName (PackageName t) = t
+
+preludePackageName :: PackageName
+preludePackageName = PackageName "prelude"
+
+untitledPackageName :: PackageName
+untitledPackageName = PackageName "untitled"

--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -27,6 +27,7 @@ executable psc-package
                    turtle ==1.3.*
     main-is: Main.hs
     other-modules: Paths_psc_package
+                   Types
     buildable: True
     hs-source-dirs: app
     ghc-options: -Wall -O2


### PR DESCRIPTION
Part of #21; this does not fully fix #21 as it only addresses package names.

Currently if the present working directory has a name which is invalid as a package name, the package is simply named "untitled". Let me know if you'd like that changed.

Also I haven't tested this as I'm not really sure how.

Some of the code is based on the code from [bower-json](http://hackage.haskell.org/package/bower-json) as I think this is a sensible set of restrictions to have on package names, and we know that everything in the ecosystem currently is valid too.