### PR TITLE
add `--pass-through` to build and repl

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -504,9 +504,9 @@ main = do
           <> Opts.short 'd'
           <> Opts.help help
 
-        passthroughArgs cmd = many $ Opts.strOption $
-             Opts.long "pass-through"
-          <> Opts.help ("Options passed through to " ++ cmd ++ "; reuse for multiple values")
+        passthroughArgs cmd = many $ Opts.strArgument $
+             Opts.help ("Options passed through to " <> cmd <> "; use -- to separate")
+          <> Opts.metavar ("`" <> cmd <> "`" <> "-options")
 
         sorted = Opts.switch $
              Opts.long "sort"


### PR DESCRIPTION
It should be possible to pass through arguments to the called `purs` commands,
like in this case `compile` and `repl`.
This is needed for e.g. using `purs compile --json-errors` to integrate
psc-package into editors.