### PR TITLE
Allow revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here is a simple project configuration:
 It defines:
 
 - The project name
-- The package set to use to resolve dependencies (this corresponds to a branch or tag of the package set source repository)
+- The package set to use to resolve dependencies (this corresponds to a SHA or tag of the package set source repository)
 - The package set source repository Git URL (change this if you want to host your own package sets)
 - Any dependencies of the project, as a list of names of packages from the package set
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -148,34 +148,31 @@ cloneShallow
   -> Turtle.FilePath
   -- ^ target directory
   -> IO ()
-cloneShallow (Repo from) (CloneTag tag) into =
-   void $ proc "git"
-                [ "clone"
-                , "-q"
-                , "-c", "advice.detachedHead=false"
-                , "--no-checkout"
-                , "-b", tag
-                , from
-                , pathToTextUnsafe into
-                ] empty .||. exit (ExitFailure 1)
-cloneShallow (Repo from) (CloneSHA sha) into = do
+cloneShallow (Repo from) tgt into = do
   void $ proc "git"
-              [ "clone"
-              , "-q"
-              , "-c", "advice.detachedHead=false"
-              , "--no-checkout"
-              , from
-              , pathToTextUnsafe into
-              ] empty .||. exit (ExitFailure 1)
-  inGitRepo $ void $ proc "git"
-                          [ "checkout"
-                          , "-q"
-                          , "-c", "advice.detachedHead=false"
-                          , "--no-checkout"
-                          , sha
-                          ] empty .||. exit (ExitFailure 1)
+               [ "clone"
+               , "-q"
+               , "-c", "advice.detachedHead=false"
+               , "--no-checkout"
+               , "-b", tgtText
+               , from
+               , pathToTextUnsafe into
+               ] empty .||. exit (ExitFailure 1)
+  case tgt of
+    CloneSHA sha ->
+      inGitRepo $ void $ proc "git"
+                             [ "checkout"
+                             , "-q"
+                             , "-c", "advice.detachedHead=false"
+                             , "--no-checkout"
+                             , sha
+                             ] empty .||. exit (ExitFailure 1)
+    CloneTag _ -> return ()
   where
     inGitRepo m = sh (pushd into >> m)
+    tgtText = case tgt of
+      CloneTag t -> t
+      CloneSHA t -> t
 
 listRemoteTags
   :: Repo

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -134,7 +134,14 @@ toCloneTarget (Repo from) raw = do
   where
     rawAsBranch = "refs/heads/" <> raw
     rawAsTag = "refs/tags/" <> raw
-    gitProc = inproc "git" ["ls-remote", "-q", "--refs", from] empty
+    gitProc = inproc "git"
+      ["ls-remote"
+      , "-q"
+      , "--refs"
+      , "--heads"
+      , "--tags"
+      , from
+      ] empty
     parseRef line = case T.splitOn "\t" line of
       [_, ref] | "refs/" `T.isPrefixOf` ref -> Just ref
       _ -> Nothing

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -118,6 +118,8 @@ data CloneTarget = CloneTag Text
                  deriving (Show)
 
 
+-- | Parses "sha:somesha", "tag:sometag", and "sometag" without a
+-- schema as a tag.
 parseCloneTarget
   :: Text
   -> Either Text CloneTarget
@@ -130,7 +132,7 @@ parseCloneTarget t =
       _ -> Left ("Invalid scheme. Expected sha: | tag: but got " <> schemeName)
   where
     (schemeName, remainder) = T.breakOn ":" t
-    withoutScheme = T.drop 3 remainder
+    withoutScheme = T.drop 1 remainder
 
 
 -- Both tags and SHAs can be treated as immutable so we only have to run this once

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -132,12 +132,12 @@ toCloneTarget (Repo from) raw = do
              then return (CloneTag raw)
              else return (CloneSHA raw)
   where
-  rawAsBranch = "refs/heads/" <> raw
-  rawAsTag = "refs/tags/" <> raw
-  gitProc = inproc "git" ["ls-remote", "-q", "--refs", from] empty
-  parseRef line = case T.splitOn "\t" line of
-    [_, ref] | "refs/" `T.isPrefixOf` ref -> Just ref
-    _ -> Nothing
+    rawAsBranch = "refs/heads/" <> raw
+    rawAsTag = "refs/tags/" <> raw
+    gitProc = inproc "git" ["ls-remote", "-q", "--refs", from] empty
+    parseRef line = case T.splitOn "\t" line of
+      [_, ref] | "refs/" `T.isPrefixOf` ref -> Just ref
+      _ -> Nothing
 
 -- Both tags and SHAs can be treated as immutable so we only have to run this once
 cloneShallow
@@ -175,7 +175,7 @@ cloneShallow (Repo from) (CloneSHA sha) into = do
                           , sha
                           ] empty .||. exit (ExitFailure 1)
   where
-  inGitRepo m = (sh (pushd into >> m))
+    inGitRepo m = sh (pushd into >> m)
 
 listRemoteTags
   :: Repo
@@ -331,17 +331,17 @@ listPackages sorted = do
     then traverse_ echoT (fmt <$> inOrder (Map.assocs db))
     else traverse_ echoT (fmt <$> Map.assocs db)
   where
-  fmt :: (PackageName, PackageInfo) -> Text
-  fmt (name, PackageInfo{ version, repo }) =
-    runPackageName name <> " (" <> version <> ", " <> unRepo repo <> ")"
+    fmt :: (PackageName, PackageInfo) -> Text
+    fmt (name, PackageInfo{ version, repo }) =
+      runPackageName name <> " (" <> version <> ", " <> unRepo repo <> ")"
 
-  inOrder xs = fromNode . fromVertex <$> vs where
-    (gr, fromVertex) =
-      G.graphFromEdges' [ (pkg, name, dependencies pkg)
-                        | (name, pkg) <- xs
-                        ]
-    vs = G.topSort (G.transposeG gr)
-    fromNode (pkg, name, _) = (name, pkg)
+    inOrder xs = fromNode . fromVertex <$> vs where
+      (gr, fromVertex) =
+        G.graphFromEdges' [ (pkg, name, dependencies pkg)
+                          | (name, pkg) <- xs
+                          ]
+      vs = G.topSort (G.transposeG gr)
+      fromNode (pkg, name, _) = (name, pkg)
 
 getSourcePaths :: PackageConfig -> PackageSet -> [PackageName] -> IO [Turtle.FilePath]
 getSourcePaths PackageConfig{..} db pkgNames = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -127,9 +127,9 @@ parseCloneTarget t =
      else case T.toLower schemeName of
       "sha" -> Right (CloneSHA withoutScheme)
       "tag" -> Right (CloneTag withoutScheme)
-      _ -> Left ("Invalid scheme. Expected sha:// | tag:// but got " <> schemeName)
+      _ -> Left ("Invalid scheme. Expected sha: | tag: but got " <> schemeName)
   where
-    (schemeName, remainder) = T.breakOn "://" t
+    (schemeName, remainder) = T.breakOn ":" t
     withoutScheme = T.drop 3 remainder
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -141,7 +141,7 @@ cloneShallow from ref into = do
                    , ref
                    ] empty .||. exit (ExitFailure 1)
   where
-  inGitRepo m = (view (pushd into >> m))
+  inGitRepo m = (sh (pushd into >> m))
 
 listRemoteTags
   :: Text

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -125,6 +125,7 @@ cloneShallow from ref into = do
          [ "clone"
          , "-q"
          , "-c", "advice.detachedHead=false"
+         , "-c", "remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*"
          , "--depth", "1"
          , from
          , pathToTextUnsafe into


### PR DESCRIPTION
This is to further the discussion we were having in #33 

I merged in upstream master so this should merge cleanly. You were asking if its possible for `git ls-remote` could be used to clean this up. I think that's for phase 2 of what I described in the original issue. The way I see it, this gets psc-package operating as-documented. Right now it says you can specify a tag or SHA. In reality, it lets you specify a branch or tag but not a SHA. It seems like supporting a branch may be a misfeature because it is not a fixed single commit but rather a moving target, yet psc-package basically assumes its a fixed target leading to some confusion.

The correct final solution here is to forbid branches, which involves some sort of git incantation to tell us what type a tree-ish is and giving a nice error message if its a branch explaining that psc-package targets must be immutable. I also suspect that once we do that, we can bring back the "exists" checks to do fewer downloads. Its totally ok if you don't want to do this half-measure, it was just the simplest solution I knew how to implement right now and solved a problem I was having.