### PR TITLE
Restore update command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -237,6 +237,12 @@ initialize setAndSource = do
     packageNameFromPWD =
       either (const untitledPackageName) id . mkPackageName
 
+update :: IO ()
+update = do
+  pkg <- readPackageFile
+  updateImpl pkg
+  echoT "Update complete"
+
 install :: String -> IO ()
 install pkgName' = do
   pkg <- readPackageFile
@@ -462,6 +468,9 @@ main = do
                                                      <*> optional (fromString <$> source))
                                    Opts.<**> Opts.helper)
             (Opts.progDesc "Initialize a new package"))
+        , Opts.command "update"
+            (Opts.info (pure update)
+            (Opts.progDesc "Update dependencies"))
         , Opts.command "uninstall"
             (Opts.info (uninstall <$> pkg Opts.<**> Opts.helper)
             (Opts.progDesc "Uninstall the named package"))


### PR DESCRIPTION
Per discussion https://github.com/purescript/psc-package/issues/32#issuecomment-304053634 the `update` command was going to be retained while folding the behaviour into `build` and `repl` but it has gone.

I usually want to cause packages to be installed without building and right now I'm running `psc-package build` and hitting Ctrl+C - I think with many non-trivial build processes this would also be the case.

(To turn the troll level down slightly - maybe `install` with no arguments could be repurposed for the `update` behaviour? More `npm install` than `stack install`)