### PR TITLE
Update cabal version

### DIFF
--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -1,5 +1,5 @@
 name:                psc-package
-version:             0.2.0
+version:             0.2.4
 synopsis:            An experimental package manager for PureScript
 description:
 homepage:            https://github.com/purescript/psc-package


### PR DESCRIPTION
With the current version `0.2.4` this was the output:

```
$ psc-package --version
0.2.0
```

I'm assuming that the version number comes from the cabal file, since this was the only reference to `0.2.0` that I could find.