### PR TITLE
`install` pulls down all dependencies when package is unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@
 ## Usage
 
 ```shell
-# install or update the dependencies listed in psc-package.json
-$ psc-package update
+# install the dependencies listed in psc-package.json
+$ psc-package install
 
 # install the package and add it to psc-package.json
 $ psc-package install <package>
+
+# update the dependencies listed in psc-package.json
+$ psc-package update
 
 # list available commands
 $ psc-package --help

--- a/README.md
+++ b/README.md
@@ -12,14 +12,11 @@
 ## Usage
 
 ```shell
-# install the dependencies listed in psc-package.json
+# install or update the dependencies listed in psc-package.json
 $ psc-package install
 
-# install the package and add it to psc-package.json
+# install or update the package and add it to psc-package.json if not listed
 $ psc-package install <package>
-
-# update the dependencies listed in psc-package.json
-$ psc-package update
 
 # list available commands
 $ psc-package --help

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -246,12 +246,17 @@ update = do
   updateImpl pkg
   echoT "Update complete"
 
-install :: String -> IO ()
+install :: Maybe String -> IO ()
 install pkgName' = do
   pkg <- readPackageFile
-  pkgName <- packageNameFromString pkgName'
-  let pkg' = pkg { depends = nub (pkgName : depends pkg) }
-  updateAndWritePackageFile pkg'
+  case pkgName' of
+    Nothing -> do
+      updateImpl pkg
+      echoT "Install complete"
+    Just str -> do
+      pkgName <- packageNameFromString str
+      let pkg' = pkg { depends = nub (pkgName : depends pkg) }
+      updateAndWritePackageFile pkg'
 
 uninstall :: String -> IO ()
 uninstall pkgName' = do
@@ -498,8 +503,8 @@ main = do
             (Opts.info (uninstall <$> pkg Opts.<**> Opts.helper)
             (Opts.progDesc "Uninstall the named package"))
         , Opts.command "install"
-            (Opts.info (install <$> pkg Opts.<**> Opts.helper)
-            (Opts.progDesc "Install the named package"))
+            (Opts.info (install <$> optional pkg Opts.<**> Opts.helper)
+            (Opts.progDesc "Install the named package, if specified. Otherwise, install all package dependencies"))
         , Opts.command "build"
             (Opts.info (exec ["purs", "compile"]
                         <$> onlyDeps "Compile only the package's dependencies"


### PR DESCRIPTION
There are a few package managers (e.g. stack, npm, bower) that overload the `install` command to install all dependencies listed in their associated configuration file when no package name is specified.

Currently the way to do this is by using the `update` command. The word "update" has different semantics than "install", to apply changes rather than fetch.

Simply adding another command `install-all` or a flag `--all` may be sufficient as well, provided that it is prominently displayed in the README.