### PR TITLE
fix(windows): Find purs.exe on Windows, if available

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -484,16 +484,17 @@ verifyPackage db paths name = do
   echoT ("Verifying package " <> runPackageName name)
   dependencies <- map fst <$> getTransitiveDeps db [name]
   let srcGlobs = map (pathToTextUnsafe . (</> ("src" </> "**" </> "*.purs")) . dirFor) dependencies
-  purs <- pursCmd
-  run purs srcGlobs
+  runPurs srcGlobs
   where
-    run :: MonadIO io => Text -> [Text] -> io ()
-    run "purs.cmd" globs =
-      let cmd = "purs.cmd"
-          args = "compile" : globs
-          s = T.intercalate " " $ cmd : args
-      in shells s empty
-    run command globs = procs command ("compile" : globs) empty
+    runPurs :: [Text] -> IO ()
+    runPurs globs = do
+      let args = "compile" : globs
+      purs <- pursCmd
+      case purs of
+        "purs.cmd" -> do
+          let s = T.intercalate " " $ purs : args
+          shells s empty
+        _ -> procs purs args empty
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -204,16 +204,13 @@ pursCmd = do
   purs <- which "purs"
   cmd <- which "purs.cmd"
   exe <- which "purs.exe"
-  let mpurs = msum [ constCmd "purs" purs
-                   , constCmd "purs" exe
-                   , constCmd "purs.cmd" cmd
+  let mpurs = msum [ "purs" <$ purs
+                   , "purs" <$ exe
+                   , "purs.cmd" <$ cmd
                    ]
   case mpurs of
     Nothing -> exitWithErr "The \"purs\" executable could not be found. Please make sure your PATH variable is set correctly"
     Just c -> return c
-    where
-      constCmd :: Text -> Maybe Turtle.FilePath -> Maybe Text
-      constCmd t = fmap (const t)
 
 getPureScriptVersion :: IO Version
 getPureScriptVersion = do


### PR DESCRIPTION
Since `purs` isn't executable on Windows, Turtle procs weren't finding
it to execute.

`purs.cmd` is executable on windows, but it must be run in a shell for
the `~%dp0` macros to expand properly. But running in a shell seems to
break on other platforms (I tested on OS X).

`purs.exe` seems to work just fine if it is on the path. If it is not
already on the path, we have to find it. In this solution, I'm just
looking for the exe relative to where the `purs.cmd` file is and
executing it.

Fixes #34 