### PR TITLE
deps: allow turtle 1.4.x

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -35,7 +35,7 @@ import           System.Environment (getArgs)
 import qualified System.IO as IO
 import qualified System.Process as Process
 import qualified Text.ParserCombinators.ReadP as Read
-import           Turtle hiding (echo, fold, s, x)
+import           Turtle hiding (echo, fold, s, x, nub)
 import qualified Turtle
 import           Types (PackageName, mkPackageName, runPackageName, untitledPackageName, preludePackageName)
 

--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -25,7 +25,7 @@ executable psc-package
                    process -any,
                    system-filepath -any,
                    text -any,
-                   turtle ==1.3.*
+                   turtle >=1.3 && <1.5
     main-is: Main.hs
     other-modules: Paths_psc_package
                    Types


### PR DESCRIPTION
This gets psc-package compiling on Nix again (turtle == 1.4.5).

This will result in a warning if turtle 1.3.x is used, which does not export `nub`. I don't know if there's a better way.