### PR TITLE
Write add from bower to local

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ import           Data.Aeson.Encode.Pretty
 import           Data.Foldable (fold, foldMap, traverse_)
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Graph as G
-import           Data.List (maximumBy, nub)
+import           Data.List (maximumBy)
 import qualified Data.List as List
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, mapMaybe)
@@ -92,6 +92,7 @@ packageConfigToJSON =
                             , "depends"
                             ]
                , confIndent = Spaces 2
+               , confTrailingNewline = True
                }
 
 packageSetToJSON :: PackageSet -> Text
@@ -100,7 +101,11 @@ packageSetToJSON =
     . TB.toLazyText
     . encodePrettyToTextBuilder' config
   where
-    config = defConfig { confCompare = compare, confIndent = Spaces 2 }
+    config = defConfig
+               { confCompare = compare
+               , confIndent = Spaces 2
+               , confTrailingNewline = True
+               }
 
 writePackageFile :: PackageConfig -> IO ()
 writePackageFile =
@@ -188,7 +193,7 @@ performInstall set pkgName PackageInfo{ repo, version } = do
 
 getReverseDeps  :: PackageSet -> PackageName -> IO [(PackageName, PackageInfo)]
 getReverseDeps db dep =
-    nub <$> foldMap go (Map.toList db)
+    List.nub <$> foldMap go (Map.toList db)
   where
     go pair@(packageName, PackageInfo {dependencies}) =
       case List.find (== dep) dependencies of
@@ -270,7 +275,7 @@ install pkgName' = do
       echoT "Install complete"
     Just str -> do
       pkgName <- packageNameFromString str
-      let pkg' = pkg { depends = nub (pkgName : depends pkg) }
+      let pkg' = pkg { depends = List.nub (pkgName : depends pkg) }
       updateAndWritePackageFile pkg'
 
 uninstall :: String -> IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -522,9 +522,8 @@ addFromBower name = do
               )
       case result' of
         Right (pkgName, info) -> do
-          pkg <- readPackageFile
-          db <- readPackageSet pkg
-          writePackageSet pkg $ Map.insert pkgName info db
+          db <- readLocalPackageSet
+          writeLocalPackageSet $ Map.insert pkgName info db
           echoT $ "Successfully wrote " <> runPackageName pkgName <> " to package set."
         Left errors -> echoT $ "Errors processing Bower Info: " <> (T.pack errors)
   where

--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -25,7 +25,7 @@ executable psc-package
                    process -any,
                    system-filepath -any,
                    text -any,
-                   turtle ==1.3.*
+                   turtle <1.6
     main-is: Main.hs
     other-modules: Paths_psc_package
                    Types

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-11.1
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
As normally expected, reads and writes from the local package file for add-from-bower. ~Adds extra dep for aeson-pretty, but probably bumping the resolver would be better in the end.~ I upgraded the resolver and upped the bounds to make this work.

```diff
⌁ 1d [:~/Code/package-sets] master ± gis
## master...origin/master
⌁ 1d [:~/Code/package-sets] master ± pp add-from-bower purescript-chanpon
Successfully wrote chanpon to package set.
⌁ 1d [:~/Code/package-sets] master(+10/-0) ± gis
## master...origin/master
 M packages.json
⌁ 1d [:~/Code/package-sets] master(+10/-0) ± gid
diff --git a/packages.json b/packages.json
index dc4ae40..0007cae 100644
--- a/packages.json
+++ b/packages.json
@@ -222,6 +222,16 @@
     "repo": "https://github.com/purescript/purescript-catenable-lists.git",
     "version": "v4.0.0"
   },
+  "chanpon": {
+    "dependencies": [
+      "eff",
+      "node-sqlite3",
+      "prelude",
+      "record"
+    ],
+    "repo": "git://github.com/justinwoo/purescript-chanpon.git",
+    "version": "v0.1.0"
+  },
   "choco-pie": {
     "dependencies": [
       "behaviors",
⌁ 1d [:~/Code/package-sets] master(+10/-0) ± 
```