### PR TITLE
remove buggy cyclic reverse dep lookup

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -193,18 +193,15 @@ performInstall set pkgName PackageInfo{ repo, version } = do
   pure pkgDir
 
 getReverseDeps  :: PackageSet -> PackageName -> IO [(PackageName, PackageInfo)]
-getReverseDeps = getReverseDeps' Set.empty
+getReverseDeps db dep =
+    List.nub <$> foldMap go (Map.toList db)
   where
-    getReverseDeps' seen db dep = List.nub <$> foldMap (go seen db dep) (Map.toList db)
-    go seen db dep pair@(packageName, PackageInfo {dependencies})
-      | packageName `Set.member` seen =
-          exitWithErr ("Cycle in package dependencies at package " <> runPackageName packageName)
-      | otherwise =
-        case List.find (== dep) dependencies of
-          Nothing -> return mempty
-          Just _ -> do
-            innerDeps <- getReverseDeps' (Set.insert packageName seen) db packageName
-            return $ pair : innerDeps
+    go pair@(packageName, PackageInfo {dependencies}) =
+      case List.find (== dep) dependencies of
+        Nothing -> return mempty
+        Just _ -> do
+          innerDeps <- getReverseDeps db packageName
+          return $ pair : innerDeps
 
 getTransitiveDeps :: PackageSet -> [PackageName] -> IO [(PackageName, PackageInfo)]
 getTransitiveDeps db deps =


### PR DESCRIPTION
Revert "crash on cyclic dependencies in reverse dependency lookup also (#105)"

This reverts commit f55533ca53d0cd8792e8fb111af88c77ffd8d031.