### PR TITLE
Limit threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+package = encoder
+
+stack_yaml = STACK_YAML="stack.yaml"
+stack = $(stack_yaml) stack
+
+build:
+	$(stack) build $(package)
+
+build-dirty:
+	$(stack) build --ghc-options=-fforce-recomp $(package)
+
+run:
+	$(stack) build --fast && $(stack) exec -- $(package)
+
+install:
+	$(stack) install
+
+ghci:
+	$(stack) ghci $(package):lib
+
+test:
+	$(stack) test $(package)
+
+test-ghci:
+	$(stack) ghci $(package):test:$(package)-tests
+
+bench:
+	$(stack) bench $(package)
+
+ghcid:
+	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):$(package)"
+
+dev-deps:
+	stack install ghcid
+
+.PHONY : build build-dirty run install ghci test test-ghci ghcid dev-deps

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-package = encoder
+package = psc-package
 
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
@@ -16,7 +16,7 @@ install:
 	$(stack) install
 
 ghci:
-	$(stack) ghci $(package):lib
+	$(stack) ghci $(package)
 
 test:
 	$(stack) test $(package)
@@ -28,7 +28,7 @@ bench:
 	$(stack) bench $(package)
 
 ghcid:
-	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):$(package)"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind'"
 
 dev-deps:
 	stack install ghcid

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,11 +10,12 @@
 module Main where
 
 import qualified Control.Foldl as Foldl
+import qualified Control.Concurrent.MSem as MSem
 import           Control.Concurrent.Async (forConcurrently_, mapConcurrently)
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.Either.Combinators (rightToMaybe)
-import           Data.Foldable (fold, foldMap, traverse_)
+import           Data.Foldable (fold, foldMap, traverse_, for_)
 import qualified Data.Graph as G
 import           Data.List (maximumBy)
 import qualified Data.List as List
@@ -505,7 +506,7 @@ verify arg = do
             Just pkgInfo -> performInstall (set pkg) pkgName pkgInfo
       echoT ("Verifying package " <> runPackageName name)
       dependencies <- map fst <$> getTransitiveDeps db [name]
-      dirs <- mapConcurrently dirFor dependencies
+      dirs <- traverse dirFor dependencies
       let srcGlobs = map (pathToTextUnsafe . (</> ("src" </> "**" </> "*.purs"))) dirs
       procs "purs" ("compile" : srcGlobs) empty
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -604,7 +604,6 @@ main = do
 
         limitThreads = Opts.option Opts.auto $
              Opts.long "threads"
-          <> Opts.value (0 :: Int)
           <> Opts.help "Limit the number of threads"
 
         source = Opts.strOption $

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,47 +1,52 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Main where
 
-import           Control.Concurrent.QSem (newQSem, waitQSem)
-import qualified Control.Foldl as Foldl
-import           Control.Concurrent.Async (forConcurrently_, mapConcurrently)
-import qualified Data.Aeson as Aeson
+import           Control.Concurrent.Async     (forConcurrently_,
+                                               mapConcurrently)
+import           Control.Concurrent.QSem      (newQSem, waitQSem)
+import qualified Control.Foldl                as Foldl
+import qualified Data.Aeson                   as Aeson
 import           Data.Aeson.Encode.Pretty
-import           Data.Either.Combinators (rightToMaybe)
-import           Data.Foldable (fold, foldMap, traverse_)
-import qualified Data.Graph as G
-import           Data.List (maximumBy)
-import qualified Data.List as List
-import qualified Data.Map as Map
-import           Data.Maybe (fromMaybe, mapMaybe)
-import           Data.Ord (comparing)
-import qualified Data.Set as Set
-import           Data.Text (pack)
-import qualified Data.Text as T
-import           Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Builder as TB
-import qualified Data.Text.Read as TR
-import           Data.Traversable (for)
-import           Data.Version (Version(..), parseVersion, showVersion)
-import qualified Filesystem.Path.CurrentOS as Path
-import           GHC.Generics (Generic)
-import qualified Options.Applicative as Opts
-import qualified Paths_psc_package as Paths
-import           System.Environment (getArgs)
-import qualified System.IO as IO
-import qualified System.Process as Process
+import           Data.Either.Combinators      (rightToMaybe)
+import           Data.Foldable                (fold, foldMap, traverse_)
+import qualified Data.Graph                   as G
+import           Data.List                    (maximumBy)
+import qualified Data.List                    as List
+import qualified Data.Map                     as Map
+import           Data.Maybe                   (fromMaybe, mapMaybe)
+import           Data.Ord                     (comparing)
+import qualified Data.Set                     as Set
+import           Data.Text                    (pack)
+import qualified Data.Text                    as T
+import           Data.Text.Encoding           (encodeUtf8)
+import qualified Data.Text.Lazy               as TL
+import qualified Data.Text.Lazy.Builder       as TB
+import qualified Data.Text.Read               as TR
+import           Data.Traversable             (for)
+import           Data.Version                 (Version (..), parseVersion,
+                                               showVersion)
+import qualified Filesystem.Path.CurrentOS    as Path
+import           GHC.Generics                 (Generic)
+import qualified Options.Applicative          as Opts
+import qualified Paths_psc_package            as Paths
+import           System.Environment           (getArgs)
+import qualified System.IO                    as IO
+import qualified System.Process               as Process
 import qualified Text.ParserCombinators.ReadP as Read
-import           Turtle hiding (arg, fold, s, x)
+import           Turtle                       hiding (arg, fold, s, x)
 import qualified Turtle
-import           Types (PackageName, mkPackageName, runPackageName, untitledPackageName, preludePackageName)
+import           Types                        (PackageName, mkPackageName,
+                                               preludePackageName,
+                                               runPackageName,
+                                               untitledPackageName)
 
 echoT :: Text -> IO ()
 echoT = Turtle.printf (Turtle.s % "\n")
@@ -448,7 +453,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
             Just tag ->
               case parsePackageVersion tag of
                 Just parts -> pure parts
-                _ -> Nothing
+                _          -> Nothing
             _ -> Nothing
         _ -> Nothing
 
@@ -463,7 +468,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
     parseDecimal s =
       case TR.decimal s of
         Right (n, "") -> Just n
-        _ -> Nothing
+        _             -> Nothing
 
     isMajorReleaseFrom :: [Int] -> [Int] -> Bool
     isMajorReleaseFrom (0 : xs) (0 : ys) = isMajorReleaseFrom xs ys
@@ -601,7 +606,7 @@ main = do
           <> Opts.help "The name of the package to install"
 
         limitJobs = Opts.option Opts.auto $
-             Opts.long "threads"
+             Opts.long "jobs"
           <> Opts.help "Limit the number of jobs that can run concurrently"
 
         source = Opts.strOption $

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -464,7 +464,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
     parseDecimal s =
       case TR.decimal s of
         Right (n, "") -> Just n
-        _             -> Nothing
+        _ -> Nothing
 
     isMajorReleaseFrom :: [Int] -> [Int] -> Bool
     isMajorReleaseFrom (0 : xs) (0 : ys) = isMajorReleaseFrom xs ys

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -448,7 +448,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
             Just tag ->
               case parsePackageVersion tag of
                 Just parts -> pure parts
-                _          -> Nothing
+                _ -> Nothing
             _ -> Nothing
         _ -> Nothing
 
@@ -463,7 +463,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
     parseDecimal s =
       case TR.decimal s of
         Right (n, "") -> Just n
-        _             -> Nothing
+        _ -> Nothing
 
     isMajorReleaseFrom :: [Int] -> [Int] -> Bool
     isMajorReleaseFrom (0 : xs) (0 : ys) = isMajorReleaseFrom xs ys

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -42,7 +42,7 @@ import qualified System.Process as Process
 import qualified Text.ParserCombinators.ReadP as Read
 import           Turtle hiding (arg, fold, s, x)
 import qualified Turtle
-import Types (PackageName, mkPackageName, runPackageName, untitledPackageName, preludePackageName)
+import           Types (PackageName, mkPackageName, runPackageName, untitledPackageName, preludePackageName)
 
 echoT :: Text -> IO ()
 echoT = Turtle.printf (Turtle.s % "\n")
@@ -449,7 +449,7 @@ checkForUpdates applyMinorUpdates applyMajorUpdates = do
             Just tag ->
               case parsePackageVersion tag of
                 Just parts -> pure parts
-                _          -> Nothing
+                _ -> Nothing
             _ -> Nothing
         _ -> Nothing
 

--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -27,8 +27,7 @@ executable psc-package
                    system-filepath -any,
                    text -any,
                    errors -any,
-                   turtle <1.6,
-                   SafeSemaphore -any
+                   turtle <1.6
     main-is: Main.hs
     other-modules: Paths_psc_package
                    Types

--- a/psc-package.cabal
+++ b/psc-package.cabal
@@ -27,7 +27,8 @@ executable psc-package
                    system-filepath -any,
                    text -any,
                    errors -any,
-                   turtle <1.6
+                   turtle <1.6,
+                   SafeSemaphore -any
     main-is: Main.hs
     other-modules: Paths_psc_package
                    Types


### PR DESCRIPTION
This is more of a "is this what you had in mind", I'm totally open to feedback.

I added a `--threads N` option for all commands that (eventually) hit a `mapConcurrently` or a `forConcurrently_`. I did it by adding a `Maybe Int` parameter down the call stack (not sure if it's worth it refactoring all of the functions to some `ReaderT env IO`; probably not with this PR but I could take that on if it would get accepted).

A value of `Nothing` means use old behaviour, otherwise use the method suggested by @kRITZCREEK's link in #126.

I would also like to keep the changes to the import because I like them arranged nicely, but I'm totally fine reverting that chunk if you want me to.

This has been tested on Appveyor on our project and fixed our issues. We have only tested with `--threads 1` so far and that works (but is obviously a bit slow).