### PR TITLE
psc-versioned branches don't exists anymore on purescript/package-sets

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -295,13 +295,12 @@ initialize setAndSource limitJobs = do
     pkg <- case setAndSource of
       Nothing -> do
         pursVersion <- getPureScriptVersion
-        echoT ("Using the default package set for PureScript compiler version " <>
-          fromString (showVersion pursVersion))
+        echoT ("Using the default package set 'master'")
         echoT "(Use --source / --set to override this behavior)"
         pure PackageConfig { name    = pkgName
                            , depends = [ preludePackageName ]
                            , source  = "https://github.com/purescript/package-sets.git"
-                           , set     = "psc-" <> pack (showVersion pursVersion)
+                           , set     = "master"
                            }
       Just (set, source) ->
         pure PackageConfig { name    = pkgName


### PR DESCRIPTION
`psc-package init` and with it `pulp --psc-package init` don't work any more right now as there is only the *master*-branch left on [purescript/package-sets](https://github.com/purescript/package-sets)

this small change should make it possible to get started again.