### PR TITLE
Bumps Stackage LTS resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: lts-11.1
+resolver: lts-14.23
 packages:
 - '.'
-extra-deps:
-- aeson-pretty-0.8.5 # newer in lts-11.1 needed for formatting packages.json
+extra-deps: []


### PR DESCRIPTION
This bumps `psc-package` to build with the latest Stackage LTS (`lts-14.23` at the time of writing).

This should resolve #157 since `lts-14.23` includes `aeson-pretty-0.8.8`, although I'm not able to reproduce this as I'm not on Windows.

In case someone else _is_ interested in trying this out on Windows, here's a link to the `purescript-book` fork at a commit that should surface the same error as reported in #157:

https://github.com/dwhitney/purescript-book/blob/51ac437475ae8b72f2cf9291c32785af4f5ba394/exercises/chapter3